### PR TITLE
아이디, 비밀번호 찾기 추가

### DIFF
--- a/src/main/java/org/galapagos/config/SecurityConfig.java
+++ b/src/main/java/org/galapagos/config/SecurityConfig.java
@@ -55,11 +55,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		http.authorizeRequests()
 			.antMatchers(
 					"/security/login", 
-					"/security/signup").permitAll()
+					"/security/signup",
+                    "/security/authentication",
+                    "/security/authenticationPassword").permitAll()
 			
 			.antMatchers("/security/profile", 
 					"/security/updateform",
-					"/security/deleteform").authenticated();
+					"/security/deleteform",
+					"/security/findIDResult").authenticated();
 
 		// 로그인 설정
 		http.formLogin()

--- a/src/main/java/org/galapagos/domain/ResetPasswordVO.java
+++ b/src/main/java/org/galapagos/domain/ResetPasswordVO.java
@@ -1,0 +1,18 @@
+package org.galapagos.domain;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.Data;
+
+@Data
+public class ResetPasswordVO {
+	
+	private String username;
+	
+	@NotBlank(message = "새로운 비밀번호를 입력하세요.")
+	private String newPassword;
+	
+	@NotBlank(message = "비밀번호를 한번 더 입력하세요.")
+	private String checkNewPassword;
+
+}

--- a/src/main/java/org/galapagos/mapper/MemberMapper.java
+++ b/src/main/java/org/galapagos/mapper/MemberMapper.java
@@ -2,6 +2,7 @@ package org.galapagos.mapper;
 
 import org.galapagos.domain.AuthorizationVO;
 import org.galapagos.domain.MemberVO;
+import org.galapagos.domain.ResetPasswordVO;
 import org.galapagos.domain.UpdateMemberVO;
 
 public interface MemberMapper {
@@ -9,6 +10,8 @@ public interface MemberMapper {
 public MemberVO readMember(String username);
 	
 	public boolean readNickname(String nickname);
+	
+	public MemberVO readEmail(String email);
 	
 	public void insertMember(MemberVO member);
 	
@@ -18,4 +21,5 @@ public MemberVO readMember(String username);
 	
 	public void deleteMember(MemberVO member);
 	
+	public void resetPassword(ResetPasswordVO resetPassword);
 }

--- a/src/main/java/org/galapagos/service/MemberService.java
+++ b/src/main/java/org/galapagos/service/MemberService.java
@@ -2,6 +2,7 @@ package org.galapagos.service;
 
 import org.galapagos.domain.DeleteMemberVO;
 import org.galapagos.domain.MemberVO;
+import org.galapagos.domain.ResetPasswordVO;
 import org.galapagos.domain.UpdateMemberVO;
 
 public interface MemberService {
@@ -9,8 +10,12 @@ public interface MemberService {
 public MemberVO getMember(String username);
 	
 	public boolean getNickname(String nickname);
+	
+	public MemberVO getEmail(String email);
 		
 	public void registerMember(MemberVO member);
+	
+	public boolean resetPassword(ResetPasswordVO resetPassword);
 	
 	public boolean updateMember(UpdateMemberVO updateMember);
 	

--- a/src/main/java/org/galapagos/service/MemberServiceImpl.java
+++ b/src/main/java/org/galapagos/service/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package org.galapagos.service;
 import org.galapagos.domain.AuthorizationVO;
 import org.galapagos.domain.DeleteMemberVO;
 import org.galapagos.domain.MemberVO;
+import org.galapagos.domain.ResetPasswordVO;
 import org.galapagos.domain.UpdateMemberVO;
 import org.galapagos.mapper.MemberMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,29 @@ public class MemberServiceImpl implements MemberService {
 	public boolean getNickname(String nickname) {
 				
 		return mapper.readNickname(nickname);
+	}
+	
+	@Override
+	public MemberVO getEmail(String email) {
+		
+		MemberVO member = mapper.readEmail(email);
+		
+		if(member == null) {
+			return null;
+		}
+		
+		return member;
+	}
+	
+	@Override
+	public boolean resetPassword(ResetPasswordVO resetPassword) {
+		
+		String encodingPassword = passwordEncoder.encode(resetPassword.getNewPassword());
+		
+		resetPassword.setNewPassword(encodingPassword);
+		mapper.resetPassword(resetPassword);
+		
+		return true;
 	}
 
 	@Override

--- a/src/main/resources/org/galapagos/mapper/MemberMapper.xml
+++ b/src/main/resources/org/galapagos/mapper/MemberMapper.xml
@@ -33,6 +33,11 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		select count(*)
 		from argument_member
 		where nickname = #{nickname}
+	</select>
+	
+	<select id="readEmail" resultType="MemberVO" parameterType="org.galapagos.domain.MemberVO">
+		select * from argument_member
+		where email = #{email}
 	</select>	
 	
 	<insert id="insertMember">
@@ -44,6 +49,12 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		insert into argument_member_authorization(username, authorization)
 		values (#{username}, #{authorization})
 	</insert>
+	
+	<update id="resetPassword" parameterType="org.galapagos.domain.ResetPasswordVO">
+		update argument_member
+		set password = #{newPassword}
+		where username = #{username}
+	</update>
 	
 	<update id="updateMember" parameterType="org.galapagos.domain.UpdateMemberVO">
 		update argument_member

--- a/src/main/webapp/WEB-INF/views/security/authentication.jsp
+++ b/src/main/webapp/WEB-INF/views/security/authentication.jsp
@@ -1,0 +1,151 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
+
+<%@ include file="../layouts/header.jsp" %>
+
+<script src="https://code.jquery.com/jquery-3.5.1.js"></script>
+
+<script>
+	$('document').ready(function() {
+		
+		var code = ""; // 인증 번호 저장
+		
+		/* 인증 번호 버튼 클릭 */
+		$('.mailCheckButton').click(function(e){
+			
+			<!-- 입력한 이메일 저장 변수 -->
+			var userMail = $('.mailInput').val(); // 입력 받은 이메일
+			var checkBox = $('.mailCheckInput'); // 인증 번호 입력 (칸 활성화 위함)
+			var boxWrap = $('.mailCheckInputBox'); // 인증 번호 입력 박스 활성화
+			var mailWarnMessage = $('.mailInputBoxWarn'); // 이메일 형식 인증 메세지
+			
+			// 형식에 맞지 않을 때 ajax가 실행되지 못하게 false 리턴해서 메소드 나감
+			if(!mailAddressCheck(userMail)) {
+				
+				alert("이메일 형식으로 입력하세요.");
+				
+				return false;
+			}
+
+			if(!userMail == ""){
+				$.ajax({
+					type: 'GET',
+					url: 'checkMail?email=' + userMail,
+					data: {userMail: userMail},
+					success: function(data){
+						
+						if(data == false){
+							alert('이메일과 일치하는 회원이 없습니다.');
+						}
+						
+						else {
+							$.ajax({
+								type:'GET',
+								url:'sendMail?email=' + userMail,
+								data: {userMail: userMail},
+								success:function(data){
+									console.log(data);
+									alert('인증번호가 발송되었습니다.');
+									checkBox.attr('disabled', false); // 인증 번호 입력 칸 속성 변경
+									boxWrap.attr('id', 'mailCheckInputBoxTrue'); // 인증 입력란 색상 변경을 위한 속성 변경
+									code = data; // controller에서 받은 인증 번호 값 저장
+								}
+							});
+						}
+					}
+					
+				});
+			}
+			
+		});
+		
+		/* 인증 번호 비교 */
+		$('.mailCheckInput').blur(function(){
+			
+			var inputCode = $('.mailCheckInput').val(); // 사용자가 입력 한 인증 번호
+			var checkCode = $('#mailCheckInputBoxWarn'); // 비교 결과 표시
+			
+			if(inputCode == code) {
+				checkCode.html('인증번호가 일치합니다.');
+				checkCode.attr('class', 'correct');
+				emailCheck = true;
+			}
+			else {
+				checkCode.html('인증번호가 일치하지 않습니다.');
+				checkCode.attr('class', 'incorrect');
+				emailCheck = false;
+			}
+		});
+		
+		// 이메일 형식 검사
+		// form에 저장 된 정규 표현식에 적합하면 true, 그렇지 않으면 false 반환 (test 메소드)
+		function mailAddressCheck(userMail) {
+			
+			var form = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
+			
+			return form.test(userMail);
+		}
+	});
+</script>
+
+<div style="width: 500px" class="mx-auto">
+	
+	<h4 class="mt-5">아이디 찾기</h4>
+	<hr>
+	<br>
+	
+	<h5>본인 확인 이메일로 인증</h5>
+	
+	<br>
+	
+	<p>가입한 이메일 주소와 입력한 이메일 주소가 같아야<br>인증 번호를 받을 수 있습니다.</p>
+	
+	<br>
+	
+	<div>
+	
+		<form action="/security/authentication" method="post" >
+			<input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
+		
+			<div class="form-group">
+				<label for="email" class="mailAddress">이메일</label>
+				<span class="mailCheckWarn"></span>
+				
+				<div class="mailInputBox">
+					<input type="text" name="email" class="mailInput" 
+					autocomplete="off" placeholder="인증 코드를 받을 이메일을 입력하세요."/>
+					<span class="emailCheck"></span>
+					<span id="mailInputBoxWarn"></span>
+				</div>
+				
+				<br>
+			
+				<div class="mailCheckWrap">
+					<div class="mailCheckInputBox" id="mailCheckInputBoxFalse">
+						<input class="mailCheckInput" disabled="disabled" placeholder="인증번호 입력">
+					</div>
+				
+					<button type="button" class="mailCheckButton">인증요청</button>
+					
+					<br>
+					<br>
+				
+					<!-- 인증 번호 일치 여부 알림 -->
+					<span id="mailCheckInputBoxWarn"></span>
+				</div>
+			</div>
+			
+			<br>
+			
+			<button type="submit" class="btn btn-primary submitBtn">확인</button>
+		
+		</form>
+	
+	</div>
+	
+</div>
+
+<%@ include file="../layouts/footer.jsp" %>

--- a/src/main/webapp/WEB-INF/views/security/authenticationPassword.jsp
+++ b/src/main/webapp/WEB-INF/views/security/authenticationPassword.jsp
@@ -1,0 +1,161 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
+<%@ include file="../layouts/header.jsp" %>
+
+<script src="https://code.jquery.com/jquery-3.5.1.js"></script>
+
+<script>
+	$('document').ready(function() {
+		
+		var code = ""; // 인증 번호 저장
+		
+		/* 인증 번호 버튼 클릭 */
+		$('.mailCheckButton').click(function(e){
+			
+			<!-- 입력한 이메일 저장 변수 -->
+			var userMail = $('.mailInput').val(); // 입력 받은 이메일
+			var checkBox = $('.mailCheckInput'); // 인증 번호 입력 (칸 활성화 위함)
+			var boxWrap = $('.mailCheckInputBox'); // 인증 번호 입력 박스 활성화
+			var mailWarnMessage = $('.mailInputBoxWarn'); // 이메일 형식 인증 메세지
+			
+			// 형식에 맞지 않을 때 ajax가 실행되지 못하게 false 리턴해서 메소드 나감
+			if(!mailAddressCheck(userMail)) {
+				
+				alert("이메일 형식으로 입력하세요.");
+				
+				return false;
+			}
+
+			if(!userMail == ""){
+				$.ajax({
+					type: 'GET',
+					url: 'checkMail?email=' + userMail,
+					data: {userMail: userMail},
+					success: function(data){
+						
+						if(data == false){
+							alert('이메일과 일치하는 회원이 없습니다.');
+						}
+						
+						else {
+							$.ajax({
+								type:'GET',
+								url:'sendMail?email=' + userMail,
+								data: {userMail: userMail},
+								success:function(data){
+									console.log(data);
+									alert('인증번호가 발송되었습니다.');
+									checkBox.attr('disabled', false); // 인증 번호 입력 칸 속성 변경
+									boxWrap.attr('id', 'mailCheckInputBoxTrue'); // 인증 입력란 색상 변경을 위한 속성 변경
+									code = data; // controller에서 받은 인증 번호 값 저장
+								}
+							});
+						}
+					}
+					
+				});
+			}
+			
+		});
+		
+		/* 인증 번호 비교 */
+		$('.mailCheckInput').blur(function(){
+			
+			var inputCode = $('.mailCheckInput').val(); // 사용자가 입력 한 인증 번호
+			var checkCode = $('#mailCheckInputBoxWarn'); // 비교 결과 표시
+			
+			if(inputCode == code) {
+				checkCode.html('인증번호가 일치합니다.');
+				checkCode.attr('class', 'correct');
+				emailCheck = true;
+			}
+			else {
+				checkCode.html('인증번호가 일치하지 않습니다.');
+				checkCode.attr('class', 'incorrect');
+				emailCheck = false;
+			}
+		});
+		
+		// 이메일 형식 검사
+		// form에 저장 된 정규 표현식에 적합하면 true, 그렇지 않으면 false 반환 (test 메소드)
+		function mailAddressCheck(userMail) {
+			
+			var form = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
+			
+			return form.test(userMail);
+		}
+	});
+</script>
+
+<div style="width: 500px" class="mx-auto">
+
+	<h4 class="mt-5">비밀번호 찾기</h4>
+	<hr>
+	
+	<br>
+	
+	<h5>본인 확인 이메일로 인증</h5>
+	
+	<br>
+	
+	<p>가입한 이메일 주소와 입력한 이메일 주소가 같아야<br>인증 번호를 받을 수 있습니다.</p>
+	
+	<br>
+	
+	<div>
+	
+		<form action="/security/authenticationPassword" method="post" >
+			<input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
+			
+			<div class="form-group">
+				<label for="username" class="usernameInput">아이디</label>
+				<br>
+				<input type="text" name="username" placeholder="아이디를 입력하세요." class="form-control"/>
+			</div>
+			
+			<br>
+		
+			<div class="form-group">
+				<label for="email" class="mailAddress">이메일</label>
+				<span class="mailCheckWarn"></span>
+				
+				<div class="mailInputBox">
+					<input type="text" name="email" class="mailInput form-control" 
+					autocomplete="off" placeholder="인증 코드를 받을 이메일을 입력하세요."/>
+					<span class="emailCheck"></span>
+					<span id="mailInputBoxWarn"></span>
+				</div>
+				
+				<br>
+			
+				<div class="mailCheckWrap">
+					<div class="mailCheckInputBox" id="mailCheckInputBoxFalse">
+						<input class="mailCheckInput" disabled="disabled" placeholder="인증번호 입력">
+					</div>
+				
+					<button type="button" class="mailCheckButton">인증요청</button>
+					
+					<br>
+					<br>
+				
+					<!-- 인증 번호 일치 여부 알림 -->
+					<span id="mailCheckInputBoxWarn"></span>
+				</div>
+			</div>
+			
+			<br>
+			
+			<button type="submit" class="btn btn-primary submitBtn">확인</button>
+		
+		</form>
+	
+	</div>
+	
+</div>
+
+<%@ include file="../layouts/footer.jsp" %>

--- a/src/main/webapp/WEB-INF/views/security/findIDResult.jsp
+++ b/src/main/webapp/WEB-INF/views/security/findIDResult.jsp
@@ -1,0 +1,43 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
+<%@ include file="../layouts/header.jsp" %>
+
+<div style="width: 500px" class="mx-auto">
+
+	<h4 class="mt-5">아이디 찾기 결과</h4>
+	<hr>
+	
+	<p>고객님의 정보와 일치하는 아이디입니다.</p>
+	
+	<br>
+	
+	<div class="form-group">
+		<label for="username"><i class="fa-solid fa-at"></i> 아이디</label>
+		<input type="text" class="form-control" id="username" value="${member.username}"
+			name="username" readonly="readonly">
+	</div>
+	
+	<br>
+	
+	<div class="form-group">
+		<label for="registerDate"><i class="fa-regular fa-calendar"></i> 가입일</label>
+		<input type="text" class="form-control" id="registerDate" 
+			value="<fmt:formatDate value="${member.registerDate}" pattern="yyyy-MM-dd"/>"
+			name="registerDate" readonly="readonly">
+	</div>
+	
+	<br>
+	
+	<div class="memberBtn">
+		<a href="/security/login" class="btn btn-primary findloginBtn">로그인</a>
+		<a href="/security/authenticationPassword" class="btn btn-primary findBtn"> 비밀번호찾기</a>
+	</div>
+
+</div>
+
+<%@ include file="../layouts/footer.jsp" %>

--- a/src/main/webapp/WEB-INF/views/security/login.jsp
+++ b/src/main/webapp/WEB-INF/views/security/login.jsp
@@ -3,6 +3,7 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
+<%@ taglib uri="http://www.springframework.org/security/tags" prefix="sec" %>
 
 <%@ include file="../layouts/header.jsp"%>
 
@@ -27,38 +28,68 @@
 			로그인이 필요한 서비스입니다.
 		</div>
 	</c:if>	
-
-	<form action="/security/login" method="post" >
-	    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
-	    <div class="form-group">
-	      <label for="username"><i class="fa-solid fa-user"></i> 사용자 ID</label>
-	      <input type="text" name="username" id="username" class="form-control" />
-	    </div>
-	    
-	    <br>
 	
-	    <div class="form-group">
-	      <label for="password"><i class="fa-solid fa-lock"></i> 비밀번호</label>
-	      <input type="password" name="password" id="password" class="form-control" />
-	    </div>
-	    
-	    <br>
+	<div>
+    	<sec:authorize access="isAnonymous()">
+        
+            <form action="/security/login" method="post" >
+            
+                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
+                
+                <div class="form-group">
+                  <label for="username">아이디</label>
+                  <input type="text" name="username" id="username" class="form-control" />
+                </div>
+                
+                <br>
+            
+                <div class="form-group">
+                  <label for="password">비밀번호</label>
+                  <input type="password" name="password" id="password" class="form-control" />
+                </div>
+                
+                <br>
+            
+                <div class="form-group form-check">
+                  <label class="form-check-label">
+                    <input class="form-check-input" type="checkbox" name="remember-me" /> 로그인 유지
+                  </label>
+                </div>
+                
+                <br>
+            
+                <button type="submit" class="btn btn-primary btn-block loginBtn">
+                  로그인
+                </button>
+                
+                <br>
+                
+                <div class="memberBtn">
+                    <a href="/security/authentication">아이디찾기</a>
+                    <a href="/security/authenticationPassword"> 비밀번호찾기</a>
+                </div>	    
+			</form>
+		</sec:authorize>
+	</div>
 	
-	    <div class="form-group form-check">
-	      <label class="form-check-label">
-	        <input class="form-check-input" type="checkbox" name="remember-me" /> 로그인 유지
-	      </label>
-	    </div>
-	    
-	    <br>
-	
-	    <button type="submit" class="btn btn-primary btn-block loginBtn">
-	      <i class="fa-solid fa-right-to-bracket"></i> 로그인
-	    </button>
-	    
-	    <br>
-	    
-	</form>
+    <sec:authorize access="isAuthenticated()">
+        
+	    <input type="hidden" name="username" value='<sec:authentication property="principal.username"/>'/>
+        
+        <div class="memberBtn">
+            <form action="/security/logout" method="post">
+                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                <input type="submit" class="btn btn-primary logoutBtn" value="로그아웃"/>
+            </form>
+            
+            <br>
+            
+            <form action="/security/profile" method="get">
+                <input type="submit" class="btn btn-primary profileBtn" value="마이페이지"/>            
+            </form>
+            
+        </div>    
+    </sec:authorize>
 </div>
 
 

--- a/src/main/webapp/WEB-INF/views/security/profile.jsp
+++ b/src/main/webapp/WEB-INF/views/security/profile.jsp
@@ -52,13 +52,16 @@
 		<br>
 		
 		<div class="memberBtn">
-				<a href="/security/updateform" class="btn btn-primary updateBtn">
-					<i class="fa-regular fa-pen-to-square"></i> 정보수정
-				</a>
-	
-				<a href="/security/deleteform" class="btn btn-primary deleteBtn">
-					<i class="fa-solid fa-user-slash"></i> 회원탈퇴
-				</a>				
+			<a href="/security/updateform" class="btn btn-primary updateBtn">
+            	정보수정
+            </a>
+            
+            <br>
+            <br>
+        
+	        <a href="/security/deleteform" class="deleteBtn">
+	            <i class="fa-solid fa-user-slash"></i> 회원탈퇴
+	        </a>                			
 		</div>
 		
 </div>

--- a/src/main/webapp/WEB-INF/views/security/resetPassword.jsp
+++ b/src/main/webapp/WEB-INF/views/security/resetPassword.jsp
@@ -1,0 +1,44 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
+
+<%@ include file="../layouts/header.jsp" %>
+
+<script src="https://code.jquery.com/jquery-3.5.1.js"></script>
+
+<div style="width: 500px" class="mx-auto">
+
+	<h4 class="mt-5">비밀번호 수정</h4>
+
+	<hr>
+	<br>
+	
+	<form:form modelAttribute="resetPassword" action="/security/resetPassword?_csrf=${_csrf.token}">
+	
+		<form:hidden path="username" value="${resetPassword.username}"/>
+	
+		<div class="form-group">
+			<form:label path="newPassword">새 비밀번호</form:label>
+			<form:password path="newPassword" class="form-control"/>
+			<form:errors path="newPassword" cssClass="error"/>
+		</div>
+		
+		<br>
+			
+		<div class="form-group">
+			<form:label path="checkNewPassword">새 비밀번호 확인</form:label>
+			<form:password path="checkNewPassword" class="form-control"/>
+			<form:errors path="checkNewPassword" cssClass="error"/>
+		</div>
+		
+		<br>
+		
+		<button type="submit" class="btn btn-primary submitBtn">수정</button>
+		
+	</form:form>
+
+</div>
+
+<%@ include file="../layouts/footer.jsp" %>

--- a/src/main/webapp/resources/css/styles.css
+++ b/src/main/webapp/resources/css/styles.css
@@ -11354,3 +11354,43 @@ body {
 .warningRed {
 	color: red;
 }
+
+.logoutBtn {
+    width: 14rem;
+    height: 2.5rem;
+    margin: auto;
+    display: inline-block;
+}
+
+.profileBtn {
+    width: 14rem;
+    height: 2.5rem;
+    margin: auto;
+    display: inline-block;
+}
+
+.memberBtn {
+    text-align: center;
+    word-spacing: 3rem;
+}
+
+.findloginBtn {
+    width: 13rem;
+    height: 2.5rem;
+    margin: auto;
+    display: inline-block;
+}
+
+.findBtn {
+    width: 13rem;
+    height: 2.5rem;
+    margin: auto;
+    display: inline-block;
+}
+
+.submitBtn {
+    width: 14rem;
+    height: 2.5rem;
+    margin: auto;
+    display: block;
+}


### PR DESCRIPTION
- 이메일 인증 받은 후 같은 이메일을 가진 회원의 정보를 찾아 아이디, 비밀번호 재설정 구현
- 로그인 페이지의 로그인 버튼 하단에 텍스트 링크 형식으로 추가
- 로그인 한 사용자가 직접 로그인 페이지 접속 시 로그아웃, 마이페이지 버튼만 보이게 설정
- 마이페이지 내 회원 탈퇴 버튼 텍스트 링크로 변경 및 정보 수정 버튼 하단에 배치